### PR TITLE
Ignore walkthroughs and .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 target/
 .idea
-.vscode
-walkthroughs
+.vscode/
+walkthroughs/
 portfolio/.*
 
 # Compiled class file


### PR DESCRIPTION
Update .gitignore to correctly ignore the entire walkthroughs and .vscode folder.